### PR TITLE
Rename go module to github.com/crc-org/routes-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/code-ready/routes-controller
+module github.com/crc-org/routes-controller
 
 go 1.18
 


### PR DESCRIPTION
This corresponds to the migration which was just done.