### PR TITLE
routes: Add host:9764 as url for expose/remove route

### DIFF
--- a/pkg/routes-handler/routes-handler.go
+++ b/pkg/routes-handler/routes-handler.go
@@ -48,13 +48,40 @@ func RoutesHandler(clientset *routeclientset.Clientset) cache.SharedIndexInforme
 	return informer
 }
 
+var addHostURLs = []string{
+	"http://gateway/hosts/add",
+	"http://host:9764/hosts/add",
+}
+
+var removeHostURLs = []string{
+	"http://gateway/hosts/remove",
+	"http://host:9764/hosts/remove",
+}
+
+// postJSON sends a POST request with JSON body to url and returns an error on failure or non-2xx status.
+func postJSON(url string, body []byte) error {
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Errorf("%s: server returned %d", url, resp.StatusCode)
+	}
+	return nil
+}
+
 func expose(host string) error {
 	bin, err := json.Marshal([]string{host})
 	if err != nil {
 		return err
 	}
-	_, err = http.Post("http://gateway/hosts/add", "application/json", bytes.NewReader(bin))
-	return err
+	for _, url := range addHostURLs {
+		if err := postJSON(url, bin); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func unexpose(host string) error {
@@ -62,6 +89,10 @@ func unexpose(host string) error {
 	if err != nil {
 		return err
 	}
-	_, err = http.Post("http://gateway/hosts/remove", "application/json", bytes.NewReader(bin))
-	return err
+	for _, url := range removeHostURLs {
+		if err := postJSON(url, bin); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
With crc-ng, we are switching to use gvproxy which doesn't have gateway API exposed so with this pr we are adding another route which is going to be running on host at 9764 port, this will also allow to use route controller for older version and new version.

On crc-ng side following we are doing
- Expose the admin helper service to different port 9764 on the host
- Use host.container.internal to access that service from the VM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Host add/remove now tries multiple endpoints for each operation, improving resilience when an endpoint is unavailable.
  * Request handling standardized for POST operations and now surfaces errors consistently (stops on first failed endpoint), reducing silent failures.
  * Host payload format for these operations remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->