### PR TITLE
Fix misc build issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: oldstable
+      - run: make lint
 
   test:
     name: Unit Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v6
+        with:
+          go-version: oldstable
+      - run: make
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
-      - run: make lint
+          go-version: oldstable
 
   test:
     name: Unit Test
@@ -27,5 +26,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: oldstable
       - run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := build
+
 TOOLS_DIR := tools
 include tools/tools.mk
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crc-org/routes-controller
 
-go 1.23.0
+go 1.25
 
 require (
 	github.com/openshift/api v0.0.0-20250305013520-e7f23be12279


### PR DESCRIPTION
Following the golangci-lint changes, more adjustment are needed, mostly related to the go version used for building. This should fix CI builds.

- **gha: Stop using `go-version-file: go.mod`**
- **build: Require go 1.25 or newer**
- **build: `make` default target should be `build`**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to version 1.25 for improved performance and compatibility.
  * Streamlined build automation and continuous integration workflow.
  * Set default build target for improved developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->