### PR TITLE
route-handler: Add bearer token auth for hosts API requests

### DIFF
--- a/pkg/routes-handler/routes-handler.go
+++ b/pkg/routes-handler/routes-handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	v1 "github.com/openshift/api/route/v1"
@@ -63,10 +64,26 @@ var removeHostURLs = []string{
 	"http://host:9764/hosts/remove",
 }
 
+func hostsAPIToken() string {
+	tok := os.Getenv("CRC_HOSTS_API_TOKEN")
+	if tok == "" {
+		log.Warn("CRC_HOSTS_API_TOKEN is not set; hosts API requests will be unauthenticated")
+	}
+	return tok
+}
+
 // postJSON sends a POST request with JSON body to url and returns an error on failure or non-2xx status.
 func postJSON(url string, body []byte) error {
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if tok := hostsAPIToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
 	//nolint:gosec // URL are constants from addHostURLs or removeHostURLs
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Read the token from the CRC_HOSTS_API_TOKEN environment variable and set it as an Authorization: Bearer header on POST requests to the hosts expose/remove endpoints. This is not going to break existing way of route controller working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved communication with the hosts API by supporting secure bearer-token authentication.
  * Added clearer configuration feedback when the required API token is not available.
  * Preserved existing request handling and error reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->